### PR TITLE
Use Vulkan or CPU instead of OpenCL

### DIFF
--- a/mlc4j/src/cpp/tvm_runtime.h
+++ b/mlc4j/src/cpp/tvm_runtime.h
@@ -21,9 +21,6 @@
 #include <runtime/module.cc>
 #include <runtime/ndarray.cc>
 #include <runtime/nvtx.cc>
-#include <runtime/opencl/opencl_device_api.cc>
-#include <runtime/opencl/opencl_module.cc>
-#include <runtime/opencl/opencl_wrapper/opencl_wrapper.cc>
 #include <runtime/profiling.cc>
 #include <runtime/source_utils.cc>
 #include <runtime/system_library.cc>


### PR DESCRIPTION
## Summary
- Try initializing JSON FFI engine with Vulkan and fall back to CPU when Vulkan support is missing
- Drop OpenCL runtime sources to avoid unneeded dependency

## Testing
- `./gradlew :mlc4j:build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e2f2da1648333be887bf3d58b66b5