### PR TITLE
Fix serialization plugin mismatch for ChatCompletionRequest

### DIFF
--- a/dist/lib/mlc4j/build.gradle
+++ b/dist/lib/mlc4j/build.gradle
@@ -1,7 +1,9 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.8.0'
+    // Use the same Kotlin Serialization plugin version as the Kotlin compiler
+    // to ensure serializers are generated correctly at build time.
+    id 'org.jetbrains.kotlin.plugin.serialization' version '2.0.21'
 }
 
 android {


### PR DESCRIPTION
## Summary
- Sync Kotlin serialization plugin with Kotlin compiler to generate serializers for ChatCompletionRequest

## Testing
- `./gradlew test` *(plugin org.jetbrains.kotlin.plugin.serialization:2.0.21 not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb5e376188333a0802eff03682afd