### PR TITLE
Show mlc4j driver to user

### DIFF
--- a/app/src/main/java/com/redornitier/cookia/MainActivity.kt
+++ b/app/src/main/java/com/redornitier/cookia/MainActivity.kt
@@ -33,6 +33,7 @@ class MainActivity : ComponentActivity() {
             MaterialTheme {
                 val ui by vm.ui.collectAsState()
                 var prompt by remember { mutableStateOf("Dame una galleta absurda sobre baterías 🔋🍪") }
+                val driver = remember { app.engine.driver }
 
                 Scaffold(
                     topBar = { CenterAlignedTopAppBar(title = { Text("BatteryCookie — MLC") }) }
@@ -46,6 +47,7 @@ class MainActivity : ComponentActivity() {
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         Text("Modelo: ${ui.modelId}", style = MaterialTheme.typography.titleMedium)
+                        Text("Driver: $driver")
 
                         Button(
                             onClick = { vm.installModel(applicationContext) },

--- a/dist/lib/mlc4j/src/main/java/ai/mlc/mlcllm/JSONFFIEngine.java
+++ b/dist/lib/mlc4j/src/main/java/ai/mlc/mlcllm/JSONFFIEngine.java
@@ -19,6 +19,7 @@ public class JSONFFIEngine {
     private Function runBackgroundStreamBackLoopFunc;
     private Function exitBackgroundLoopFunc;
     private Function requestStreamCallback;
+    private String driverType = "unknown";
 
     public JSONFFIEngine() {
         Function createFunc = Function.getFunction("mlc.json_ffi.CreateJSONFFIEngine");
@@ -37,7 +38,14 @@ public class JSONFFIEngine {
     }
 
     public void initBackgroundEngine(KotlinFunction callback) {
-        Device device = Device.opencl();
+        Device device;
+        try {
+            device = Device.opencl();
+            driverType = "GPU (OpenCL)";
+        } catch (Throwable t) {
+            device = Device.cpu();
+            driverType = "CPU";
+        }
 
         requestStreamCallback = Function.convertFunc(new Function.Callback() {
             @Override
@@ -50,6 +58,10 @@ public class JSONFFIEngine {
 
         initBackgroundEngineFunc.pushArg(device.deviceType).pushArg(device.deviceId).pushArg(requestStreamCallback)
                 .invoke();
+    }
+
+    public String getDriverType() {
+        return driverType;
     }
 
     public void reload(String engineConfigJSONStr) {

--- a/dist/lib/mlc4j/src/main/java/ai/mlc/mlcllm/MLCEngine.kt
+++ b/dist/lib/mlc4j/src/main/java/ai/mlc/mlcllm/MLCEngine.kt
@@ -26,6 +26,8 @@ class MLCEngine {
     private val state: EngineState
     private val jsonFFIEngine: JSONFFIEngine
     val chat: Chat
+    val driver: String
+        get() = jsonFFIEngine.driverType
     private val threads = mutableListOf<BackgroundWorker>()
 
     init {


### PR DESCRIPTION
## Summary
- detect GPU or CPU backend in JSONFFIEngine and expose driver type
- surface driver type through MLCEngine
- display MLCEngine driver on main screen

## Testing
- `./gradlew build` *(fails: SDK location not found)*
- `./gradlew :mlc4j:build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a0e360ec833380d5208cd97039b0